### PR TITLE
Add playful empty state illustrations

### DIFF
--- a/Reconnect/Views/Friends/FriendListView.swift
+++ b/Reconnect/Views/Friends/FriendListView.swift
@@ -59,7 +59,11 @@ struct FriendListView: View {
                 LinearGradient.warmBackground.ignoresSafeArea()
 
                 if friends.isEmpty {
-                    emptyState
+                    EmptyFriendsView {
+                        showingAddFriend = true
+                    }
+                } else if filteredFriends.isEmpty {
+                    NoSearchResultsView(searchText: searchText)
                 } else {
                     ScrollView {
                         VStack(spacing: Spacing.md) {
@@ -113,31 +117,6 @@ struct FriendListView: View {
     }
 
     // MARK: - Subviews
-
-    private var emptyState: some View {
-        VStack(spacing: Spacing.lg) {
-            Image(systemName: "person.2.fill")
-                .font(.system(size: 60))
-                .foregroundStyle(Color.coral.opacity(0.5))
-
-            VStack(spacing: Spacing.xs) {
-                Text("No friends yet")
-                    .font(.displaySmall)
-                    .foregroundStyle(Color.warmBlack)
-
-                Text("Add someone you want to stay in touch with")
-                    .font(.bodyMedium)
-                    .foregroundStyle(Color.warmGrayDark)
-                    .multilineTextAlignment(.center)
-            }
-
-            PrimaryButton("Add Your First Friend", icon: "plus") {
-                showingAddFriend = true
-            }
-            .frame(maxWidth: 280)
-        }
-        .padding(Spacing.xl)
-    }
 
     private var statusSummary: some View {
         HStack(spacing: Spacing.sm) {
@@ -224,7 +203,206 @@ private struct FilterPill: View {
     }
 }
 
-#Preview {
+// MARK: - Empty Friends View
+
+private struct EmptyFriendsView: View {
+    var onAddFriend: () -> Void
+
+    @State private var isAnimating = false
+    @State private var heartsVisible = false
+
+    var body: some View {
+        VStack(spacing: Spacing.lg) {
+            // Playful illustration using SF Symbols and shapes
+            ZStack {
+                // Background decorative circles
+                Circle()
+                    .fill(Color.lavender.opacity(0.3))
+                    .frame(width: 160, height: 160)
+                    .scaleEffect(isAnimating ? 1.05 : 1.0)
+
+                Circle()
+                    .fill(Color.coralLight.opacity(0.4))
+                    .frame(width: 120, height: 120)
+                    .scaleEffect(isAnimating ? 0.95 : 1.0)
+
+                // Main icon
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 50))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Color.coral, Color.coralDark],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .offset(y: isAnimating ? -3 : 3)
+
+                // Floating hearts
+                ForEach(0..<3, id: \.self) { index in
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(floatingHeartColor(for: index))
+                        .offset(floatingHeartOffset(for: index))
+                        .opacity(heartsVisible ? 1 : 0)
+                        .scaleEffect(heartsVisible ? 1 : 0.5)
+                }
+
+                // Sparkles
+                Image(systemName: "sparkle")
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.sunflower)
+                    .offset(x: 55, y: -35)
+                    .opacity(isAnimating ? 1 : 0.5)
+                    .scaleEffect(isAnimating ? 1.2 : 0.8)
+
+                Image(systemName: "sparkle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color.sage)
+                    .offset(x: -50, y: -40)
+                    .opacity(isAnimating ? 0.5 : 1)
+                    .scaleEffect(isAnimating ? 0.8 : 1.2)
+            }
+            .frame(height: 180)
+
+            VStack(spacing: Spacing.sm) {
+                Text("Your friend list is waiting to bloom")
+                    .font(.displaySmall)
+                    .foregroundStyle(Color.warmBlack)
+                    .multilineTextAlignment(.center)
+
+                Text("Add someone special to stay connected with")
+                    .font(.bodyMedium)
+                    .foregroundStyle(Color.warmGrayDark)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, Spacing.lg)
+
+            PrimaryButton("Add Your First Friend", icon: "plus") {
+                onAddFriend()
+            }
+            .frame(maxWidth: 280)
+        }
+        .padding(Spacing.xl)
+        .onAppear {
+            withAnimation(
+                .easeInOut(duration: 2.0)
+                    .repeatForever(autoreverses: true)
+            ) {
+                isAnimating = true
+            }
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.6).delay(0.3)) {
+                heartsVisible = true
+            }
+        }
+    }
+
+    private func floatingHeartColor(for index: Int) -> Color {
+        let colors: [Color] = [.coral, .lavenderDark, .sage]
+        return colors[index % colors.count]
+    }
+
+    private func floatingHeartOffset(for index: Int) -> CGSize {
+        let offsets: [CGSize] = [
+            CGSize(width: -45, height: -20),
+            CGSize(width: 50, height: -10),
+            CGSize(width: 0, height: -55),
+        ]
+        return offsets[index % offsets.count]
+    }
+}
+
+// MARK: - No Search Results View
+
+private struct NoSearchResultsView: View {
+    let searchText: String
+
+    @State private var isAnimating = false
+
+    var body: some View {
+        VStack(spacing: Spacing.lg) {
+            // Playful magnifying glass illustration
+            ZStack {
+                // Background circle
+                Circle()
+                    .fill(Color.sageLight.opacity(0.4))
+                    .frame(width: 140, height: 140)
+
+                // Magnifying glass with friendly face
+                ZStack {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 60, weight: .light))
+                        .foregroundStyle(Color.warmGrayDark)
+                        .rotationEffect(.degrees(isAnimating ? -5 : 5))
+
+                    // Friendly question marks floating around
+                    Image(systemName: "questionmark")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Color.coral.opacity(0.7))
+                        .offset(x: 35, y: -25)
+                        .scaleEffect(isAnimating ? 1.1 : 0.9)
+
+                    Image(systemName: "questionmark")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(Color.lavenderDark.opacity(0.7))
+                        .offset(x: -30, y: -30)
+                        .scaleEffect(isAnimating ? 0.9 : 1.1)
+                }
+            }
+            .frame(height: 160)
+
+            VStack(spacing: Spacing.sm) {
+                Text("No friends found")
+                    .font(.displaySmall)
+                    .foregroundStyle(Color.warmBlack)
+
+                if searchText.isEmpty {
+                    Text("Try adjusting your filters")
+                        .font(.bodyMedium)
+                        .foregroundStyle(Color.warmGrayDark)
+                        .multilineTextAlignment(.center)
+                } else {
+                    Text("No one matches \"\(searchText)\"")
+                        .font(.bodyMedium)
+                        .foregroundStyle(Color.warmGrayDark)
+                        .multilineTextAlignment(.center)
+
+                    Text("Try a different search term")
+                        .font(.bodySmall)
+                        .foregroundStyle(Color.warmGrayDark.opacity(0.8))
+                }
+            }
+            .padding(.horizontal, Spacing.lg)
+        }
+        .padding(Spacing.xl)
+        .onAppear {
+            withAnimation(
+                .easeInOut(duration: 1.5)
+                    .repeatForever(autoreverses: true)
+            ) {
+                isAnimating = true
+            }
+        }
+    }
+}
+
+#Preview("Empty Friends") {
+    ZStack {
+        LinearGradient.warmBackground.ignoresSafeArea()
+        EmptyFriendsView {
+            print("Add friend tapped")
+        }
+    }
+}
+
+#Preview("No Search Results") {
+    ZStack {
+        LinearGradient.warmBackground.ignoresSafeArea()
+        NoSearchResultsView(searchText: "John")
+    }
+}
+
+#Preview("Full List") {
     FriendListView()
         .modelContainer(for: [Friend.self, ContactLog.self], inMemory: true)
 }


### PR DESCRIPTION
## Summary
This PR implements Issue #3 by adding playful, animated empty state illustrations to FriendListView.

## Changes

### EmptyFriendsView (when friend list is empty)
- Creative SF Symbol composition with `person.2.fill` icon
- Animated background circles using lavender and coral colors
- Floating hearts in coral, lavender, and sage colors
- Sparkle decorations with subtle pulsing animation
- Warm, encouraging copy: "Your friend list is waiting to bloom"
- Smooth entrance animations using SwiftUI springs

### NoSearchResultsView (when search/filter returns no results)
- Animated magnifying glass with gentle rotation
- Floating question marks to convey the "searching" feeling
- Contextual messaging:
  - With search text: "No one matches '[search term]'"
  - With filters only: "Try adjusting your filters"

## Design Decisions
- All animations are subtle and non-distracting (slow easing, small movements)
- Uses existing design system colors (coral, sage, lavender, sunflower)
- Copy is positive and encouraging, not guilt-inducing
- Smooth transitions when state changes

## Testing
- Added SwiftUI Previews for both empty state variations
- Build succeeds with no errors

## Screenshots
The empty states feature:
- Pulsing background circles
- Floating hearts with spring animations
- Sparkle effects
- Gentle icon movement

Closes #3